### PR TITLE
added warning message with all taxa ids which are not in the local da…

### DIFF
--- a/R/createTaxonomyMatrix.R
+++ b/R/createTaxonomyMatrix.R
@@ -117,8 +117,20 @@ getTaxonomyInfo <- function(inputTaxa = NULL, currentNCBIinfo = NULL) {
     tmp <- list()
     outList <- list()
     k <- 1
+    missingTaxa <- setdiff(inputTaxa, currentNCBIinfo$ncbiID)
+    if (length(missingTaxa) > 0) {
+    	warning(
+    		cat(length(missingTaxa), 
+    		    "id(s) missed in currentNCBIinfo, check taxon database: ",
+    	             paste(missingTaxa, collapse = ", ")
+    	            )
+    	)
+    }
     for (refID in inputTaxa) {
         # get info for this taxon
+        if (refID %in% missingTaxa) {
+	    next
+        }
         refEntry <- currentNCBIinfo[currentNCBIinfo$ncbiID == refID, ]
         lastID <- refEntry$parentID
         inputTaxaInfo <- refEntry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a check for taxonomy IDs in the getTaxonomyInfo function. 
If the IDs are not present in currentNCBIinfo$ncbiID, they are printed as a warning message.
## Related Issue
The usage of getRepresentative from taxFun currently throws only a single exception when the user-provided Taxonomy ID is not in the local database. 
This means that if the input list contains multiple problematic IDs, it requires multiple calls to identify all of them. This update addresses the issue by improving the error handling for such cases.